### PR TITLE
Fix attribute array type

### DIFF
--- a/lib/open_api_annotator/components_builder.rb
+++ b/lib/open_api_annotator/components_builder.rb
@@ -28,11 +28,22 @@ module OpenApiAnnotator
       properties = {}
       serializer.open_api_attributes.each do |attribute|
         next unless attribute.valid?
-        properties[attribute.name.to_sym] = OpenApi::Schema.new(
-          type: attribute.type,
-          format: attribute.format,
-          nullable: attribute.nullable,
-        )
+        properties[attribute.name.to_sym] = if attribute.type.is_a?(Array)
+          OpenApi::Schema.new(
+            type: "array",
+            items: OpenApi::Schema.new(
+              type: attribute.type.first,
+              format: attribute.format,
+              nullable: attribute.nullable,
+            )
+          )
+        else
+          OpenApi::Schema.new(
+            type: attribute.type,
+            format: attribute.format,
+            nullable: attribute.nullable,
+          )
+        end
       end
       properties
     end

--- a/spec/open_api_annotator/components_builder_spec.rb
+++ b/spec/open_api_annotator/components_builder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe OpenApiAnnotator::ComponentsBuilder do
     let(:has_one_association) { OpenApiAnnotator::Association.new("cover_image", CoverImage, true) }
     let(:belongs_to_association) { OpenApiAnnotator::Association.new("publisher", Publisher, false) }
     let(:attribute) { OpenApiAnnotator::Attribute.new("published_at", "string", "date-time", false) }
+    let(:array_attribute) { OpenApiAnnotator::Attribute.new("tags", ["string"], nil, false) }
 
     before do
       stub_const("BookSerializer", Class.new(ActiveModel::Serializer))
@@ -23,7 +24,7 @@ RSpec.describe OpenApiAnnotator::ComponentsBuilder do
       allow(BookSerializer).to receive(:open_api_has_many_associations).and_return([has_many_association])
       allow(BookSerializer).to receive(:open_api_has_one_associations).and_return([has_one_association])
       allow(BookSerializer).to receive(:open_api_belongs_to_associations).and_return([belongs_to_association])
-      allow(BookSerializer).to receive(:open_api_attributes).and_return([attribute])
+      allow(BookSerializer).to receive(:open_api_attributes).and_return([attribute, array_attribute])
       allow(BookSerializer).to receive(:open_api_resource_name).and_return("Book")
     end
 
@@ -34,6 +35,10 @@ RSpec.describe OpenApiAnnotator::ComponentsBuilder do
             type: "object",
             properties: {
               published_at: OpenApi::Schema.new(type: "string", format: "date-time"),
+              tags: OpenApi::Schema.new(
+                type: "array",
+                items: OpenApi::Schema.new(type: "string", format: nil)
+              ),
               authors: OpenApi::Schema.new(
                 type: "array",
                 items: OpenApi::Reference.new(ref: "#/components/schemas/Author"),


### PR DESCRIPTION
I fixed this problem.

```rb
class HogeSerializer
  attribute(:tag_names, type: [:string], nullable: false) { object.tags.map(&:name) }
end
```

### Before
```yaml
Hoge:
  tag_names:
    type:
      - string
```

### After
```yaml
Hoge:
  tag_names:
    type: array
    items:
      type: string
```