### PR TITLE
Enable to annotate primitive types to endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ language: ruby
 rvm:
   - 2.4.4
   - 2.5.1
-before_install: gem install bundler -v 1.16.1
+before_install:
+  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.5.1
 before_install:
   - gem install -v 1.17.3 bundler --no-rdoc --no-ri
+  - bundle _1.17.3_ install
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/lib/open_api_annotator/paths_builder.rb
+++ b/lib/open_api_annotator/paths_builder.rb
@@ -64,8 +64,8 @@ module OpenApiAnnotator
 
     def build_type_name(type)
       case type
-      when Symbol
-        "#{type.to_s}"
+      when OpenApi::DataType
+        "#{type.name}"
       when Class
         "#{type.name}"
       else
@@ -90,8 +90,8 @@ module OpenApiAnnotator
 
     def resolve_media_type_schema(type)
       case type
-      when Symbol
-        OpenApi::Schema.new(type: type.to_s, format: nil)
+      when OpenApi::DataType
+        OpenApi::Schema.new(type: type.name, format: type.format)
       when Class
         OpenApi::Reference.new(ref: "#/components/schemas/#{type.name}")
       else

--- a/lib/open_api_annotator/paths_builder.rb
+++ b/lib/open_api_annotator/paths_builder.rb
@@ -63,6 +63,7 @@ module OpenApiAnnotator
     end
 
     def build_type_name(type)
+      type = convert_primitive_class_to_data_type(type)
       case type
       when OpenApi::DataType
         "#{type.name}"
@@ -89,6 +90,7 @@ module OpenApiAnnotator
     end
 
     def resolve_media_type_schema(type)
+      type = convert_primitive_class_to_data_type(type)
       case type
       when OpenApi::DataType
         OpenApi::Schema.new(type: type.name, format: type.format)
@@ -96,6 +98,18 @@ module OpenApiAnnotator
         OpenApi::Reference.new(ref: "#/components/schemas/#{type.name}")
       else
         raise "not supported class #{type.class}"
+      end
+    end
+
+    def convert_primitive_class_to_data_type(type)
+      if type == String
+        OpenApi::DataType.new(:string, :string, :string)
+      elsif type == Integer
+        OpenApi::DataType.new(:integer, :integer, :int32)
+      elsif type == Float
+        OpenApi::DataType.new(:float, :number, :float)
+      else
+        type
       end
     end
 

--- a/spec/open_api_annotator/paths_builder_spec.rb
+++ b/spec/open_api_annotator/paths_builder_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
       )
       allow(Api::V1::StringsController).to receive(:endpoint_hash).and_return(
         {
-          index: OpenApiAnnotator::Endpoint.new([:string]),
-          show: OpenApiAnnotator::Endpoint.new(:string),
+          index: OpenApiAnnotator::Endpoint.new([OpenApi::DataType.new(:string, :string)]),
+          show: OpenApiAnnotator::Endpoint.new(OpenApi::DataType.new(:string, :string)),
         }
       )
     end
@@ -166,7 +166,7 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
                 description: "Returns a string",
                 content: {
                   "application/json" => OpenApi::MediaType.new(
-                    schema: OpenApi::Schema.new(type: "string", format: nil)
+                    schema: OpenApi::Schema.new(type: :string, format: nil)
                   )
                 }
               )
@@ -198,7 +198,7 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
                   "application/json" => OpenApi::MediaType.new(
                     schema: OpenApi::Schema.new(
                       type: "array",
-                      items: OpenApi::Schema.new(type: "string", format: nil)
+                      items: OpenApi::Schema.new(type: :string, format: nil)
                     )
                   )
                 }

--- a/spec/open_api_annotator/paths_builder_spec.rb
+++ b/spec/open_api_annotator/paths_builder_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
       )
       allow(Api::V1::StringsController).to receive(:endpoint_hash).and_return(
         {
-          index: OpenApiAnnotator::Endpoint.new([OpenApi::DataType.new(:string, :string)]),
-          show: OpenApiAnnotator::Endpoint.new(OpenApi::DataType.new(:string, :string)),
+          index: OpenApiAnnotator::Endpoint.new([String]),
+          show: OpenApiAnnotator::Endpoint.new(String),
         }
       )
     end
@@ -166,7 +166,7 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
                 description: "Returns a string",
                 content: {
                   "application/json" => OpenApi::MediaType.new(
-                    schema: OpenApi::Schema.new(type: :string, format: nil)
+                    schema: OpenApi::Schema.new(type: :string, format: :string)
                   )
                 }
               )
@@ -198,7 +198,7 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
                   "application/json" => OpenApi::MediaType.new(
                     schema: OpenApi::Schema.new(
                       type: "array",
-                      items: OpenApi::Schema.new(type: :string, format: nil)
+                      items: OpenApi::Schema.new(type: :string, format: :string)
                     )
                   )
                 }

--- a/spec/open_api_annotator/paths_builder_spec.rb
+++ b/spec/open_api_annotator/paths_builder_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
     before do
       stub_const("Api::BaseController", Class.new(ActionController::Base))
       stub_const("Api::V1::BooksController", Class.new(Api::BaseController))
+      stub_const("Api::V1::StringsController", Class.new(Api::BaseController))
       stub_const("Book", Class.new)
 
       config = double(:config)
@@ -54,6 +55,12 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
           index: OpenApiAnnotator::Endpoint.new([Book]),
           show: OpenApiAnnotator::Endpoint.new(Book),
           update: OpenApiAnnotator::Endpoint.new(Book),
+        }
+      )
+      allow(Api::V1::StringsController).to receive(:endpoint_hash).and_return(
+        {
+          index: OpenApiAnnotator::Endpoint.new([:string]),
+          show: OpenApiAnnotator::Endpoint.new(:string),
         }
       )
     end
@@ -138,5 +145,69 @@ RSpec.describe OpenApiAnnotator::PathsBuilder do
         )
       end
     end
+
+    context "when media type is symbol" do
+      let(:routes) do
+        [
+          OpenApiAnnotator::Route.new(
+            http_verb: "GET",
+            path: "/api/v1/strings/{id}",
+            controller_name: "api/v1/strings",
+            action_name: "show",
+          ),
+        ]
+      end
+
+      it "returns OpenApi::PathItem" do
+        is_expected.to eq OpenApi::PathItem.new(
+          get: OpenApi::Operation.new(
+            responses: OpenApi::Responses.new(
+              "200": OpenApi::Response.new(
+                description: "Returns a string",
+                content: {
+                  "application/json" => OpenApi::MediaType.new(
+                    schema: OpenApi::Schema.new(type: "string", format: nil)
+                  )
+                }
+              )
+            )
+          )
+        )
+      end
+    end
+
+    context "when media type is array of symbol" do
+      let(:routes) do
+        [
+          OpenApiAnnotator::Route.new(
+            http_verb: "GET",
+            path: "/api/v1/strings",
+            controller_name: "api/v1/strings",
+            action_name: "index",
+          ),
+        ]
+      end
+
+      it "returns OpenApi::PathItem" do
+        is_expected.to eq OpenApi::PathItem.new(
+          get: OpenApi::Operation.new(
+            responses: OpenApi::Responses.new(
+              "200": OpenApi::Response.new(
+                description: "Returns an array of string",
+                content: {
+                  "application/json" => OpenApi::MediaType.new(
+                    schema: OpenApi::Schema.new(
+                      type: "array",
+                      items: OpenApi::Schema.new(type: "string", format: nil)
+                    )
+                  )
+                }
+              )
+            )
+          )
+        )
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I want annotate primitive types like string to endpoints.
When use symbols, annotate those symbol types as follows.

```
class BooksController
  extend OpenApiAnnotator::ControllerAnnotatable

  endpoint [:string]
  def index
    # some code
  end
end
```

```
 "books":
    get:
      responses:
        '200':
          description: Returns an array of string
          content:
            application/json:
              schema:
                type: array
                items:
                  type: string
```