### PR TITLE
Add default_skip_open_api_validation option

### DIFF
--- a/lib/open_api_annotator/config.rb
+++ b/lib/open_api_annotator/config.rb
@@ -6,6 +6,7 @@ module OpenApiAnnotator
     :application_controller_class_name,
     :application_serializer_class_name,
     :always_required_fields,
+    :default_skip_open_api_validation,
   )
     def application_serializer_class
       if application_serializer_class_name

--- a/lib/open_api_annotator/configurable.rb
+++ b/lib/open_api_annotator/configurable.rb
@@ -9,7 +9,7 @@ module OpenApiAnnotator
       end
 
       def config
-        @config ||= Config.new
+        @config ||= Config.new(nil, nil, nil, nil, nil, false)
       end
     end
   end

--- a/lib/open_api_annotator/serializer_annotatable.rb
+++ b/lib/open_api_annotator/serializer_annotatable.rb
@@ -7,6 +7,10 @@ module OpenApiAnnotator
         @open_api_validation_skipped = true
       end
 
+      def use_open_api_validation!
+        @open_api_validation_skipped = false
+      end
+
       def attribute(attr, options = {}, &block)
         validate_open_api_options(attr, options)
         super(attr, options, &block)
@@ -28,7 +32,7 @@ module OpenApiAnnotator
       end
 
       def validate_open_api_options(field, options)
-        return if @open_api_validation_skipped
+        return if skip_open_api_validation?
 
         validate_open_api_type!(options[:type])
         validate_open_api_format!(options[:format])
@@ -94,6 +98,13 @@ module OpenApiAnnotator
 
       def open_api_resource_name
         name.remove(/Serializer\z/)
+      end
+
+      private
+
+      def skip_open_api_validation?
+        return @open_api_validation_skipped unless @open_api_validation_skipped.nil?
+        OpenApiAnnotator.config.default_skip_open_api_validation
       end
     end
   end


### PR DESCRIPTION
The annotation function of this gem is very very useful.
But in our project, we use annotation optionally.
We often forget adding `skip_open_api_validation!`, so our project has many warnings.

I suggest to add `default_skip_open_api_validation` option.

```rb
OpenApiAnnotator.configure do |config|
  config.info = ...
  config.destination_path = ...
  config.path_regexp = ...
  config.application_controller_class_name = ...
  config.application_serializer_class_name = ...
  config.always_required_fields = ...
  config.default_skip_open_api_validation = true
end

```

And I added `use_open_api_validation!` method to use validation partially.

```rb
class FooSerializer < ApplicationSerializer
  use_open_api_validation!

  attribute(:id, type: :integer, nullable: false)
  ...
end
```