### PR TITLE
Improve validation warning

### DIFF
--- a/lib/open_api_annotator/serializer_annotatable.rb
+++ b/lib/open_api_annotator/serializer_annotatable.rb
@@ -34,7 +34,7 @@ module OpenApiAnnotator
         validate_open_api_format!(options[:format])
         validate_open_api_nullable!(options[:nullable])
       rescue ValidationError => e
-        Rails.logger.warn(e.message)
+        Rails.logger.warn("Within #{self.name}, #{field}: #{e.message}")
       end
 
       def validate_open_api_type!(type)


### PR DESCRIPTION
## Why

In order to facilitate fixing missing/incorrect annotations.

## What

Display the serializer name and the field name along the validation error.

#### Before

```
nullable should not be nil.
nullable should not be nil.
nullable should not be nil.
type should not be nil.
```

#### After

```
Within UserSerializer, graduated_on_year: nullable should not be nil.
Within UserSerializer, graduated_on_month: nullable should not be nil.
Within AccountSerializer, email: nullable should not be nil.
Within Api::IceCreamSerializer, perfume: type should not be nil.
```