### PR TITLE
Reflect ownership transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Not released yet
 
+- Reflect ownership transfer https://github.com/wantedly/open_api_annotator/pull/18
+
 ## 0.6.0
 - Support Ruby 3.0 and Rails 6.1
 ## 0.5.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at ngtknt@me.com. All
+reported by contacting the project team at dev@wantedly.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenApiAnnotator [![Gem Version](https://badge.fury.io/rb/open_api_annotator.svg)](https://badge.fury.io/rb/open_api_annotator) [![Build Status](https://travis-ci.org/ngtk/open_api_annotator.svg?branch=master)](https://travis-ci.org/ngtk/open_api_annotator) [![Maintainability](https://api.codeclimate.com/v1/badges/8be7a273496459c62190/maintainability)](https://codeclimate.com/github/ngtk/open_api_annotator/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/8be7a273496459c62190/test_coverage)](https://codeclimate.com/github/ngtk/open_api_annotator/test_coverage)
+# OpenApiAnnotator [![Gem Version](https://badge.fury.io/rb/open_api_annotator.svg)](https://badge.fury.io/rb/open_api_annotator) [![Build Status](https://travis-ci.org/wantedly/open_api_annotator.svg?branch=master)](https://travis-ci.org/wantedly/open_api_annotator) [![Maintainability](https://api.codeclimate.com/v1/badges/8be7a273496459c62190/maintainability)](https://codeclimate.com/github/wantedly/open_api_annotator/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/8be7a273496459c62190/test_coverage)](https://codeclimate.com/github/wantedly/open_api_annotator/test_coverage)
 
 OpenApiAnnotator realizes to generate OpenAPI spec by annotating to controllers and serializers.
 If you use ActiveModelSerializer, this is the best way to generate OpenAPI spec.
@@ -80,7 +80,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/ngtk/open_api_annotator. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/wantedly/open_api_annotator. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -88,4 +88,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the OpenApiAnnotator project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/ngtk/open_api_annotator/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the OpenApiAnnotator project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/wantedly/open_api_annotator/blob/master/CODE_OF_CONDUCT.md).

--- a/open_api_annotator.gemspec
+++ b/open_api_annotator.gemspec
@@ -6,12 +6,12 @@ require "open_api_annotator/version"
 Gem::Specification.new do |spec|
   spec.name          = "open_api_annotator"
   spec.version       = OpenApiAnnotator::VERSION
-  spec.authors       = ["Kent Nagata"]
-  spec.email         = ["ngtknt@me.com"]
+  spec.authors       = ["Kent Nagata", "Wantedly, Inc."]
+  spec.email         = ["ngtknt@me.com", "dev@wantedly.com"]
 
   spec.summary       = %q{OpenApi spec generation by bottom-up.}
   spec.description   = %q{OpenApiAnnotator realizes to generate OpenApi spec by annotating to Controller and ActiveModelSerializer.}
-  spec.homepage      = "https://github.com/ngtk/open_api_annotator"
+  spec.homepage      = "https://github.com/wantedly/open_api_annotator"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
## Why

The ownership had been transferred from ngtk/open_api to wantedly/open_api.

## What

Reflect the change in the source code.